### PR TITLE
Change GitHub stats links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,9 @@ Here are some ideas to get you started:
 <!--
 [![Anurag's GitHub stats-Light](https://github-readme-stats.vercel.app/api?username=jvachier&show_icons=true&theme=default#gh-light-mode-only)](https://github.com/jvachier/github-readme-stats#gh-light-mode-only)
 [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=jvachier&layout=compact&count_private=true)](https://github.com/jvachier/github-readme-stats)
--->
-
 ![Top Langs](https://github-readme-stats-sigma-five.vercel.app/api/top-langs/?username=jvachier&layout=compact&hide_progress=true)
 ![GitHub Stats](https://github-readme-stats-sigma-five.vercel.app/api?username=jvachier&rank_icon=github)
+-->
 
 ![Python](https://img.shields.io/badge/Python-3776AB?style=flat&logo=python&logoColor=white)
 ![C++](https://img.shields.io/badge/C++-00599C?style=flat&logo=cplusplus&logoColor=white)


### PR DESCRIPTION
Updated GitHub stats images to use a new URL and removed old stats.